### PR TITLE
fix: update cached time(now) when remove job

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -245,6 +245,7 @@ func (c *Cron) run() {
 
 			case id := <-c.remove:
 				timer.Stop()
+                                now = c.now()
 				delete(c.entries, id)
 
 			case <-c.snapshot:


### PR DESCRIPTION
Hi, https://github.com/AliyunContainerService/kubernetes-cronhpa-controller imports the go-cron lib, when I read it, I find a little bug.
if job be removed,  beause of the variable(now)'s loss of updating,  the job queue's next time to execute will be delayed.
and the delayed time is related with the interval between the time of job queue's removes and the time of the lastest add/update/start time.